### PR TITLE
Added documentjs and docs homepage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/**
+docs/**

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,12 +1,22 @@
 var path = require("path");
+var docConfig = require('./documentjs.json');
 var isCI = process.env.CI === 'true';
 
 module.exports = function (grunt) {
 
 	grunt.loadNpmTasks('steal-tools');
 	grunt.loadNpmTasks('testee');
+  	grunt.loadNpmTasks('documentjs');
+  	grunt.loadNpmTasks('grunt-serve');
 
-	grunt.initConfig({
+	var config = {
+		docConfig: docConfig,
+		serve: {
+			options: {
+				path: './',
+				port: '8000'
+			}
+		},
 		testee: {
 			options: {
 				reporter: 'Spec'
@@ -37,7 +47,11 @@ module.exports = function (grunt) {
 				}
 			}
 		}
-	});
+	};
+	
+	grunt.initConfig(config);
+	grunt.registerTask('server',['serve']);
 	grunt.registerTask('build',['steal-export']);
 	grunt.registerTask('test', [ isCI ? 'testee:ci' : 'testee:local' ]);
+	grunt.registerTask('docs', ['documentjs']);
 };

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
-# bit-strap
+@page bitstrap
+@hide sidebar
+@hide title
+@hide footer
+@hide article
+@body
+
+# BitStrap
+
 can.Component wrapper for Bootstrap

--- a/documentjs.json
+++ b/documentjs.json
@@ -1,0 +1,18 @@
+{
+    "sites": {
+        "docs": {
+            "glob" : {
+              "pattern": "./**/*.{js,md}",
+              "ignore": "./{bower_components,node_modules,docs,dist}/**/*.*"
+            },
+            "dest" : "./docs",
+            "parent" : "bitstrap",
+            "package":{
+                "repository": {
+                    "github": "https://github.com/bitovi-components/bit-strap"
+                },
+                "version":"0.0.1"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   },
   "devDependencies": {
     "bower": "1.3.8",
+    "documentjs": "^0.3.0-pre.1",
     "grunt": "~0.4.1",
     "grunt-cli": "^0.1.13",
+    "grunt-serve": "^0.1.6",
     "jquery": ">1.9.0",
     "steal": "^0.7.1",
     "steal-qunit": "0.0.2",
@@ -32,7 +34,11 @@
   },
   "system": {
     "main": "bit-strap",
-    "transpiler": "babel"
+    "transpiler": "babel",
+    "npmIgnore": [
+      "testee",
+      "documentjs"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Added DocumentJS.

We should just be able to add the demo's of each BitStrap component to the README.md file and point to each component's api page.

![image](https://cloud.githubusercontent.com/assets/2633542/6833419/fa61f342-d2fa-11e4-8523-6ad964382e32.png)
